### PR TITLE
Highlight rebar group in 3D viewer when clicked in sidebar table (#14)

### DIFF
--- a/e2e/highlight-rebar.spec.js
+++ b/e2e/highlight-rebar.spec.js
@@ -1,0 +1,141 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+/**
+ * E2E tests for highlighting rebar groups between table and 3D viewer.
+ */
+
+test.describe('Highlight rebar group from table', () => {
+  let elemId;
+  let bottomSurfaceId;
+
+  test.beforeEach(async ({ request }) => {
+    // Clear elements
+    const resp = await request.get('/api/elements');
+    const elements = await resp.json();
+    for (const elem of elements) {
+      await request.delete(`/api/elements/${elem.id}`);
+    }
+
+    // Create a rectangle element with two rebar groups
+    const createResp = await request.post('/api/elements/from-preset', {
+      data: {
+        name: 'Highlight Test',
+        preset_type: 'rectangle',
+        params: { width: 24, height: 36, length: 120 },
+      },
+    });
+    const elem = await createResp.json();
+    elemId = elem.id;
+    bottomSurfaceId = elem.surfaces.find((s) => s.name === 'bottom').id;
+
+    await request.post(`/api/elements/${elemId}/rebar-groups`, {
+      data: {
+        surface_id: bottomSurfaceId,
+        label: 'A1',
+        bar_size: '#5',
+        spacing: 6.0,
+        cover: 1.5,
+      },
+    });
+
+    await request.post(`/api/elements/${elemId}/rebar-groups`, {
+      data: {
+        surface_id: bottomSurfaceId,
+        label: 'A2',
+        bar_size: '#4',
+        spacing: 8.0,
+        cover: 1.5,
+      },
+    });
+  });
+
+  test('clicking table row highlights rebar group in 3D viewer', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.click('.elem-item');
+    await page.click('[data-step="rebar"]');
+    await page.waitForTimeout(1000);
+
+    // Get the first rebar row's group ID
+    const groupId = await page
+      .locator('.rebar-table tbody tr[data-group-id]')
+      .first()
+      .getAttribute('data-group-id');
+
+    // Click the first rebar row
+    await page.locator('.rebar-table tbody tr[data-group-id]').first().click();
+
+    // Verify 3D viewer has the group selected
+    const selectedId = await page.evaluate(() => {
+      return window.rebarViewer3D?.selectedGroupId;
+    });
+    expect(selectedId).toBe(groupId);
+
+    // Verify table row has highlight class
+    await expect(
+      page.locator(`.rebar-table tbody tr[data-group-id="${groupId}"]`)
+    ).toHaveClass(/highlight/);
+  });
+
+  test('clicking same row again clears highlight (toggle)', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.click('.elem-item');
+    await page.click('[data-step="rebar"]');
+    await page.waitForTimeout(1000);
+
+    const row = page.locator('.rebar-table tbody tr[data-group-id]').first();
+
+    // Click to select
+    await row.click();
+    let selectedId = await page.evaluate(
+      () => window.rebarViewer3D?.selectedGroupId
+    );
+    expect(selectedId).not.toBeNull();
+
+    // Click again to deselect
+    await row.click();
+    selectedId = await page.evaluate(
+      () => window.rebarViewer3D?.selectedGroupId
+    );
+    expect(selectedId).toBeNull();
+
+    // Row should not have highlight class
+    await expect(row).not.toHaveClass(/highlight/);
+  });
+
+  test('clicking different row moves highlight', async ({ page }) => {
+    await page.goto('/');
+    await page.click('.elem-item');
+    await page.click('[data-step="rebar"]');
+    await page.waitForTimeout(1000);
+
+    const rows = page.locator('.rebar-table tbody tr[data-group-id]');
+    const row1 = rows.nth(0);
+    const row2 = rows.nth(1);
+
+    const groupId1 = await row1.getAttribute('data-group-id');
+    const groupId2 = await row2.getAttribute('data-group-id');
+
+    // Click first row
+    await row1.click();
+    let selectedId = await page.evaluate(
+      () => window.rebarViewer3D?.selectedGroupId
+    );
+    expect(selectedId).toBe(groupId1);
+    await expect(row1).toHaveClass(/highlight/);
+    await expect(row2).not.toHaveClass(/highlight/);
+
+    // Click second row
+    await row2.click();
+    selectedId = await page.evaluate(
+      () => window.rebarViewer3D?.selectedGroupId
+    );
+    expect(selectedId).toBe(groupId2);
+    await expect(row2).toHaveClass(/highlight/);
+    await expect(row1).not.toHaveClass(/highlight/);
+  });
+});

--- a/scratchpads/highlight-rebar-3d.md
+++ b/scratchpads/highlight-rebar-3d.md
@@ -1,0 +1,28 @@
+# Highlight rebar group in 3D viewer when clicked in sidebar table
+
+Issue: https://github.com/mrcurrie21/RebarHelper/issues/14
+
+## Plan
+
+### Step 1: Add `highlightGroup()` / `clearHighlight()` to `viewer3d.js`
+- `highlightGroup(groupId)`: set emissive glow on all meshes with matching `userData.groupId`, clear others
+- `clearHighlight()`: reset all rebar meshes to no emissive glow, set `selectedGroupId = null`
+- Toggle logic: if same groupId is already selected, clear instead
+
+### Step 2: Wire table row clicks in `app.js`
+- Add click handler on `<tr data-group-id="...">` rows in `renderRebarStep()`
+- On click: toggle highlight via `viewer3d.highlightGroup(groupId)`
+- Update table row `.highlight` CSS class to match
+- Ensure the existing `viewer3d.onGroupSelected` callback (3D click -> table highlight) still works
+
+### Step 3: Add E2E test
+- Create element, add rebar group
+- Click table row, verify 3D highlight via `selectedGroupId`
+- Click again to deselect, verify cleared
+- Click in 3D viewer, verify table row gets highlighted
+
+## Notes
+
+- `viewer3d.js` `_onClick` already has emissive highlight logic — extract into reusable methods
+- `app.js` already has `viewer3d.onGroupSelected` wiring for 3D-click -> table-row highlight
+- Table rows already have `data-group-id` attribute set

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -59,16 +59,31 @@ async function init() {
   });
 
   viewer3d.onGroupSelected = (groupId) => {
-    // Highlight table row
-    document.querySelectorAll('.rebar-table tr').forEach(r => r.classList.remove('highlight'));
+    // Highlight table row when bar clicked in 3D viewer
+    highlightTableRow(groupId);
+  };
+
+  loadElementList();
+}
+
+// --- Rebar Row Highlight ---
+
+function highlightTableRow(groupId) {
+  document.querySelectorAll('.rebar-table tr').forEach(r => r.classList.remove('highlight'));
+  if (groupId) {
     const row = document.querySelector(`tr[data-group-id="${groupId}"]`);
     if (row) {
       row.classList.add('highlight');
       row.scrollIntoView({ block: 'nearest' });
     }
-  };
+  }
+}
 
-  loadElementList();
+function onRebarRowClick(groupId) {
+  if (!viewer3d) return;
+  viewer3d.highlightGroup(groupId);
+  // Update table row highlight to match viewer state (toggle may have cleared it)
+  highlightTableRow(viewer3d.selectedGroupId);
 }
 
 // --- Element List ---
@@ -306,7 +321,7 @@ async function renderRebarStep() {
       ? `${hookLabels[g.start_hook] || '-'} / ${hookLabels[g.end_hook] || '-'}`
       : '-';
     return `
-    <tr data-group-id="${g.id}">
+    <tr data-group-id="${g.id}" onclick="onRebarRowClick('${g.id}')" style="cursor:pointer">
       <td>${esc(g.label)}</td>
       <td>${surfName}</td>
       <td>${g.bar_size}</td>
@@ -600,6 +615,7 @@ window.submitRebarGroup = submitRebarGroup;
 window.deleteRebarGroup = deleteRebarGroup;
 window.saveData = saveData;
 window.updateCrossSection = updateCrossSection;
+window.onRebarRowClick = onRebarRowClick;
 
 // Start
 init();

--- a/static/js/viewer3d.js
+++ b/static/js/viewer3d.js
@@ -175,9 +175,10 @@ class RebarViewer3D {
       const groupId = hit.userData.groupId;
       this.highlightGroup(groupId);
 
-      if (this.onGroupSelected) this.onGroupSelected(groupId);
+      if (this.onGroupSelected) this.onGroupSelected(this.selectedGroupId);
     } else {
       this.clearHighlight();
+      if (this.onGroupSelected) this.onGroupSelected(null);
     }
   }
 

--- a/static/js/viewer3d.js
+++ b/static/js/viewer3d.js
@@ -135,6 +135,33 @@ class RebarViewer3D {
     this.renderer.render(this.scene, this.camera);
   }
 
+  highlightGroup(groupId) {
+    // Toggle: if already selected, clear instead
+    if (this.selectedGroupId === groupId) {
+      this.clearHighlight();
+      return;
+    }
+
+    this.clearHighlight();
+    this.selectedGroupId = groupId;
+
+    this.rebarGroup.children.forEach(child => {
+      if (child.userData.groupId === groupId) {
+        child.material.emissive.setHex(0x444444);
+      }
+    });
+  }
+
+  clearHighlight() {
+    this.rebarGroup.children.forEach(child => {
+      if (child.userData.originalColor !== undefined) {
+        child.material.color.setHex(child.userData.originalColor);
+        child.material.emissive.setHex(0x000000);
+      }
+    });
+    this.selectedGroupId = null;
+  }
+
   _onClick(event) {
     const rect = this.renderer.domElement.getBoundingClientRect();
     this.mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
@@ -143,28 +170,14 @@ class RebarViewer3D {
     this.raycaster.setFromCamera(this.mouse, this.camera);
     const intersects = this.raycaster.intersectObjects(this.rebarGroup.children, true);
 
-    // Reset previous selection
-    this.rebarGroup.children.forEach(child => {
-      if (child.userData.originalColor !== undefined) {
-        child.material.color.setHex(child.userData.originalColor);
-        child.material.emissive.setHex(0x000000);
-      }
-    });
-
     if (intersects.length > 0) {
       const hit = intersects[0].object;
       const groupId = hit.userData.groupId;
-      this.selectedGroupId = groupId;
-
-      this.rebarGroup.children.forEach(child => {
-        if (child.userData.groupId === groupId) {
-          child.material.emissive.setHex(0x444444);
-        }
-      });
+      this.highlightGroup(groupId);
 
       if (this.onGroupSelected) this.onGroupSelected(groupId);
     } else {
-      this.selectedGroupId = null;
+      this.clearHighlight();
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `highlightGroup()`/`clearHighlight()` methods to `viewer3d.js`, refactoring existing click-to-highlight logic to use them
- Wire table row clicks in `app.js` to call `viewer3d.highlightGroup(groupId)` with toggle behavior (re-click clears, switching rows moves highlight)
- Add 3 E2E tests covering select, toggle-off, and switch-between-rows behavior

Closes #14

## Test plan
- [x] All 87 backend tests pass
- [x] All 22 E2E tests pass (19 existing + 3 new)
- [x] Ruff lint and format checks pass
- [ ] CI passes on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)